### PR TITLE
Fixed dependencies to avoid undefined RSpec.configure method error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-request_snapshot (0.1.0)
+    rspec-request_snapshot (0.1.1)
       rspec (~> 3.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rspec-request_snapshot (0.1.0)
+      rspec (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,7 +36,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   rake (~> 10.0)
-  rspec (~> 3.0)
   rspec-request_snapshot!
   simplecov (~> 0.16.1)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ expect(response.body).to match_snapshot("api/resources_index")
 expect(response.body).to match_snapshot("api/resources_index", format: :text)
 
 # Defining specific test dynamic attributes
-expect(response.body).to match_snapshot("api/resources_index", dyanmic_attributes: %w(confirmed_at relation_id))
+expect(response.body).to match_snapshot("api/resources_index", dynamic_attributes: %w(confirmed_at relation_id))
 ```
 
 ## Development

--- a/lib/rspec/request_snapshot.rb
+++ b/lib/rspec/request_snapshot.rb
@@ -1,3 +1,4 @@
+require "rspec"
 require "rspec/request_snapshot/version"
 require "rspec/request_snapshot/config"
 require "rspec/request_snapshot/matcher"

--- a/lib/rspec/request_snapshot/version.rb
+++ b/lib/rspec/request_snapshot/version.rb
@@ -1,5 +1,5 @@
 module Rspec
   module RequestSnapshot
-    VERSION = "0.1.1".freeze
+    VERSION = "0.1.2".freeze
   end
 end

--- a/lib/rspec/request_snapshot/version.rb
+++ b/lib/rspec/request_snapshot/version.rb
@@ -1,5 +1,5 @@
 module Rspec
   module RequestSnapshot
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.1".freeze
   end
 end

--- a/rspec-request_snapshot.gemspec
+++ b/rspec-request_snapshot.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rspec", "~> 3.0"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.16.1"
 end


### PR DESCRIPTION
There is an issue where the gem throws an error `undefined RSpec.configure method error` due to it being called before rspec is included. This fixes the error.