### PR TITLE
Fixed bugs where comparing snapshots with arrays would fail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-request_snapshot (0.2.0)
+    rspec-request_snapshot (0.3.0)
       rspec (~> 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ expect(response.body).to match_snapshot("api/resources_index", ignore_order: %w(
 - If you are using it for arrays of objects/hashes (ie: `[{name: "name", value: "value"}, ...]`),
 it won't perform well depending on the array and hash size (number of keys)
 
-- Due to limitations on sorting array of objects/hashes, it might fail for cases where nested arrays are present
+- Due to limitations on sorting array of objects/hashes, `ignore_order` might fail for cases where the array elements
+don't have matching keys. For example, it is hard to sort the following arrays in a consistent way
+(even tho they have the same elements):
+
+```
+[{z: 2, a: 2}, {b: 5, z: 1}, {a: 2, b: 5}, {c: 10, a: 2, b: 3}, {d: 4, a: 1}, {d: 6, b: 1}, {a: [1, 3]}, {a: {a: 1}}]
+[{a: {a: 1}}, {z: 2, a: 2}, {b: 5, z: 1}, {d: 6, b: 1}, {a: 2, b: 5}, {c: 10, a: 2, b: 3}, {a: [1, 3]}, {d: 4, a: 1}]
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,37 @@ expect(response.body).to match_snapshot("api/resources_index")
 
 # Using plain text instead of parsing JSON
 expect(response.body).to match_snapshot("api/resources_index", format: :text)
+```
 
+#### Matcher options
+
+##### dynamic_attributes
+
+Using `dynamic_attributes` inline allows to ignore attributes for a specific snapshot.
+This is useful to ignore changing attributes, like `id` or `created_at`.
+Notice that **all** nodes matching those (nested or not) will be ignored. Usage:
+
+```ruby
 # Defining specific test dynamic attributes
 expect(response.body).to match_snapshot("api/resources_index", dynamic_attributes: %w(confirmed_at relation_id))
+```
 
+##### ignore_order
+
+It is possible to use the `ignore_order` inline option to mark which array nodes are unsorted and that elements position
+should not be taken into consideration.
+
+```ruby
 # Ignoring order for certain arrays (this will ignore the ordering for the countries array inside the json response)
 expect(response.body).to match_snapshot("api/resources_index", ignore_order: %w(countries))
 ```
+
+**Note:** `ignore_order` has some limitations:
+
+- If you are using it for arrays of objects/hashes (ie: `[{name: "name", value: "value"}, ...]`),
+it won't perform well depending on the array and hash size (number of keys)
+
+- Due to limitations on sorting array of objects/hashes, it might fail for cases where nested arrays are present
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -81,19 +81,8 @@ should not be taken into consideration.
 expect(response.body).to match_snapshot("api/resources_index", ignore_order: %w(countries))
 ```
 
-**Note:** `ignore_order` has some limitations:
-
-- If you are using it for arrays of objects/hashes (ie: `[{name: "name", value: "value"}, ...]`),
+**Note:** If you are using `ignore_order` for arrays of objects/hashes (ie: `[{name: "name", value: "value"}, ...]`),
 it won't perform well depending on the array and hash size (number of keys)
-
-- Due to limitations on sorting array of objects/hashes, `ignore_order` might fail for cases where the array elements
-don't have matching keys. For example, it is hard to sort the following arrays in a consistent way
-(even tho they have the same elements):
-
-```
-[{z: 2, a: 2}, {b: 5, z: 1}, {a: 2, b: 5}, {c: 10, a: 2, b: 3}, {d: 4, a: 1}, {d: 6, b: 1}, {a: [1, 3]}, {a: {a: 1}}]
-[{a: {a: 1}}, {z: 2, a: 2}, {b: 5, z: 1}, {d: 6, b: 1}, {a: 2, b: 5}, {c: 10, a: 2, b: 3}, {a: [1, 3]}, {d: 4, a: 1}]
-```
 
 ## Development
 

--- a/lib/rspec/request_snapshot/handlers/base.rb
+++ b/lib/rspec/request_snapshot/handlers/base.rb
@@ -8,5 +8,9 @@ module Rspec::RequestSnapshot::Handlers
       @dynamic_attributes ||= RSpec.configuration.request_snapshots_dynamic_attributes |
                               Array(@options[:dynamic_attributes])
     end
+
+    def ignore_order
+      @ignore_order ||= @options[:ignore_order] || []
+    end
   end
 end

--- a/lib/rspec/request_snapshot/version.rb
+++ b/lib/rspec/request_snapshot/version.rb
@@ -1,5 +1,5 @@
 module Rspec
   module RequestSnapshot
-    VERSION = "0.2.0".freeze
+    VERSION = "0.3.0".freeze
   end
 end

--- a/spec/fixtures/snapshots/api/array_dynamic_attributes.json
+++ b/spec/fixtures/snapshots/api/array_dynamic_attributes.json
@@ -1,0 +1,12 @@
+{
+  "objects": [
+    {
+      "id": 10,
+      "value": "value 10"
+    },
+    {
+      "id": 20,
+      "value": "value 20"
+    }
+  ]
+}

--- a/spec/fixtures/snapshots/api/complex_json.json
+++ b/spec/fixtures/snapshots/api/complex_json.json
@@ -1,0 +1,107 @@
+{
+  "data": {
+    "books": [
+      {
+        "id": 22,
+        "name": "two"
+      },
+      {
+        "id": 11,
+        "name": "one"
+      }
+    ],
+    "value": "value"
+  },
+  "objects": [
+    {
+      "pens": [
+        {
+          "id": 40,
+          "name": "one",
+          "prices": [
+            1,
+            3,
+            2
+          ]
+        },
+        {
+          "id": 50,
+          "name": "two",
+          "prices": [
+            7,
+            5,
+            6
+          ]
+        }
+      ],
+      "computers": [
+        {
+          "id": 10,
+          "name": "computer one",
+          "pieces": [
+            {
+              "id": 10,
+              "name": "one",
+              "prices": [
+                1,
+                2,
+                3
+              ]
+            },
+            {
+              "id": 20,
+              "name": "two",
+              "prices": [
+                4,
+                5,
+                6
+              ]
+            },
+            {
+              "id": 30,
+              "name": "three",
+              "prices": [
+                7,
+                8,
+                9
+              ]
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "name": "computer two",
+          "pieces": [
+            {
+              "id": 10,
+              "name": "one",
+              "prices": [
+                11,
+                12,
+                13
+              ]
+            },
+            {
+              "id": 20,
+              "name": "two",
+              "prices": [
+                14,
+                15,
+                16
+              ]
+            },
+            {
+              "id": 30,
+              "name": "three",
+              "prices": [
+                17,
+                18,
+                19
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/snapshots/api/ordering_objects.json
+++ b/spec/fixtures/snapshots/api/ordering_objects.json
@@ -1,0 +1,12 @@
+{
+  "objects": [
+    {
+      "id": 10,
+      "value": "value 10"
+    },
+    {
+      "id": 20,
+      "value": "value 20"
+    }
+  ]
+}


### PR DESCRIPTION
* Snapshots with dynamic attributes inside object arrays now work properly
* Nested array comparisons now work properly
* Better relying on rspec diffable feature by transforming hashes and performing a simple comparison