### PR TITLE
Make the default format configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ RSpec.configure do |config|
   # The json attributes that ignore order when comparing nodes
   # Default value is []
   config.request_snapshots_ignore_order = %w(array_node)
+
+  # The default format to use, other formats must be specified using the :format option
+  # Default value is :json
+  config.request_snapshots_default_format = :json
 end
 ```
 

--- a/lib/rspec/request_snapshot/config.rb
+++ b/lib/rspec/request_snapshot/config.rb
@@ -3,5 +3,6 @@ module Rspec::RequestSnapshot
     config.add_setting :request_snapshots_dir, default: "spec/fixtures/snapshots"
     config.add_setting :request_snapshots_dynamic_attributes, default: %w(id created_at updated_at)
     config.add_setting :request_snapshots_ignore_order, default: %w()
+    config.add_setting :request_snapshots_default_format, default: :json
   end
 end

--- a/lib/rspec/request_snapshot/matcher.rb
+++ b/lib/rspec/request_snapshot/matcher.rb
@@ -30,7 +30,7 @@ module Rspec::RequestSnapshot
     end
 
     def format
-      @options[:format]&.to_sym || :json
+      @options[:format]&.to_sym || RSpec.configuration.request_snapshots_default_format
     end
 
     def handler

--- a/spec/rspec/request_snapshot_spec.rb
+++ b/spec/rspec/request_snapshot_spec.rb
@@ -128,8 +128,23 @@ RSpec.describe Rspec::RequestSnapshot do
   end
 
   describe "format" do
+    let(:sample_text) { "My text test" }
+
     it "matches snapshot with text format" do
-      expect("My text test").to match_snapshot("api/text", format: :text)
+      expect(sample_text).to match_snapshot("api/text", format: :text)
+    end
+
+    it "defaults to json format when not specified" do
+      expect(RSpec.configuration.request_snapshots_default_format).to eq :json
+    end
+
+    context "when the configured format is set to :text" do
+      before { RSpec.configuration.request_snapshots_default_format = :text }
+      after { RSpec.configuration.request_snapshots_default_format = :json }
+
+      it "matches text without passing the format argument" do
+        expect(sample_text).to match_snapshot("api/text")
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not using :json format for the tests I have so far.  I thought it might be useful to make the default format configurable.