### PR TITLE
Added support for dynamic attributes regex matching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.5-node-browsers
+       - image: circleci/ruby:2.1
 
     working_directory: ~/repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [v0.6.0]
+
+### Fixed
+- Removed code that made gem compatible only with ruby >= 2.3
+
+### Added
+- Added support for regex on dynamic attributes
+- Added a CHANGELOG.md file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-request_snapshot (0.5.0)
+    rspec-request_snapshot (0.6.0)
       rspec (~> 3.0)
 
 GEM
@@ -40,4 +40,4 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Notice that **all** nodes matching those (nested or not) will be ignored. Usage:
 expect(response.body).to match_snapshot("api/resources_index", dynamic_attributes: %w(confirmed_at relation_id))
 ```
 
+##### dynamic_attributes with regex
+
+Sometimes you don't want to fully ignore an attribute. For example, you want to make sure
+that `generated_id` is present and following a given pattern, but that attribute can change
+randonly, use `dynamic_attributes` with object/regex notation:
+
+```ruby
+# Example generated_id: ABC-001
+expect(response.body).to match_snapshot("api/resources_index", dynamic_attributes: [{ generated_id: /^\w{3}-\d{3}$/ }])
+```
+
+**Note:** Partial matches are also possible, so use the start/end of line characters for a strict match
+
 ##### ignore_order
 
 It is possible to use the `ignore_order` inline option to mark which array nodes are unsorted and that elements position

--- a/lib/rspec/request_snapshot/handlers/base.rb
+++ b/lib/rspec/request_snapshot/handlers/base.rb
@@ -2,18 +2,37 @@
 
 module Rspec::RequestSnapshot::Handlers
   class Base
+    attr_reader :dynamic_attributes_with_regex
+
     def initialize(options = {})
       @options = options
     end
 
     def dynamic_attributes
-      @dynamic_attributes ||= RSpec.configuration.request_snapshots_dynamic_attributes |
-                              Array(@options[:dynamic_attributes])
+      @dynamic_attributes ||= begin
+        list = RSpec.configuration.request_snapshots_dynamic_attributes | Array(@options[:dynamic_attributes])
+        strip_attributes_with_regex(list)
+      end
     end
 
     def ignore_order
       @ignore_order ||= RSpec.configuration.request_snapshots_ignore_order |
                         Array(@options[:ignore_order])
+    end
+
+    private
+
+    def strip_attributes_with_regex(list)
+      @dynamic_attributes_with_regex = {}
+      list.map do |element|
+        if element.is_a?(String)
+          element
+        else
+          key = element.keys.first.to_s
+          @dynamic_attributes_with_regex[key] = element.values.first
+          key
+        end
+      end
     end
   end
 end

--- a/lib/rspec/request_snapshot/handlers/json.rb
+++ b/lib/rspec/request_snapshot/handlers/json.rb
@@ -18,7 +18,7 @@ class Rspec::RequestSnapshot::Handlers::JSON < Rspec::RequestSnapshot::Handlers:
   def deep_transform_values(hash)
     hash.each_key do |key|
       if dynamic_attributes.include?(key)
-        hash[key] = "REPLACED"
+        handle_dynamic_attribute(hash, key)
         next
       end
 
@@ -41,5 +41,13 @@ class Rspec::RequestSnapshot::Handlers::JSON < Rspec::RequestSnapshot::Handlers:
 
   def sort_elements(hash, key)
     hash[key].first.is_a?(Hash) ? hash[key].sort_by! { |e| e.keys.map { |k| e[k] } } : hash[key].sort!
+  end
+
+  def handle_dynamic_attribute(hash, key)
+    if dynamic_attributes_with_regex.key?(key)
+      hash[key] = dynamic_attributes_with_regex[key] if dynamic_attributes_with_regex[key].match(hash[key].to_s)
+    else
+      hash[key] = "IGNORED"
+    end
   end
 end

--- a/lib/rspec/request_snapshot/matcher.rb
+++ b/lib/rspec/request_snapshot/matcher.rb
@@ -32,7 +32,7 @@ module Rspec::RequestSnapshot
     end
 
     def format
-      @options[:format]&.to_sym || RSpec.configuration.request_snapshots_default_format
+      (@options[:format] && @options[:format].to_sym) || RSpec.configuration.request_snapshots_default_format
     end
 
     def handler

--- a/lib/rspec/request_snapshot/version.rb
+++ b/lib/rspec/request_snapshot/version.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Style/ClassAndModuleChildren
 module Rspec
   module RequestSnapshot
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end
 # rubocop:enable Style/ClassAndModuleChildren

--- a/spec/rspec/request_snapshot_spec.rb
+++ b/spec/rspec/request_snapshot_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Rspec::RequestSnapshot do
 
   describe "dynamic attributes" do
     it "ignores default dynamic attributes" do
-      json = { id: 99, created_at: false, updated_at: Time.now }.to_json
+      json = { id: 99, created_at: false, updated_at: Time.now.iso8601 }.to_json
       expect(json).to match_snapshot("api/dynamic_attributes")
     end
 
@@ -54,6 +54,23 @@ RSpec.describe Rspec::RequestSnapshot do
     it "ignores nodes inside object arrays" do
       json = { objects: [{ id: 10, value: "value 10" }, { id: 22, value: "value 20" }] }.to_json
       expect(json).to match_snapshot("api/array_dynamic_attributes", dynamic_attributes: %w(id))
+    end
+  end
+
+  describe "regex dynamic attributes" do
+    it "matches with matching regex" do
+      json = { id: 99, created_at: false, updated_at: Time.now }.to_json
+      expect(json).to match_snapshot("api/dynamic_attributes", dynamic_attributes: [{ id: /^\d{2}$/ }])
+    end
+
+    it "matches with partial matching regex" do
+      json = { id: 999, created_at: false, updated_at: Time.now }.to_json
+      expect(json).to match_snapshot("api/dynamic_attributes", dynamic_attributes: [{ id: /\d{2}/ }])
+    end
+
+    it "fails with not matching regex" do
+      json = { id: 100, created_at: false, updated_at: Time.now }.to_json
+      expect(json).not_to match_snapshot("api/dynamic_attributes", dynamic_attributes: [{ id: /^\d{2}$/ }])
     end
   end
 


### PR DESCRIPTION
- Added support for dynamic attributes regex matching
- Fixed gem code to be compatible with older ruby versions >= 2.0 (didn't test even older ones) 